### PR TITLE
Add min_confirmations argument to balance & spend methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@
   instead inferred from the script).
 - `zcashlc_shield_funds` now takes the transparent account private key as an
   argument instead of the transparent spending key for a single P2PKH address.
+- `zcashlc_get_verified_balance` now takes the minimum number of confirmations
+  used to filter received notes as an argument.
+- `zcashlc_get_verified_transparent_balance` now takes the minimum number of
+  confirmations used to filter received notes as an argument.
+- `zcashlc_get_total_transparent_balance` now returns a balance that includes
+  all UTXOs up to those in the latest block (i.e. those with 0 confirmations.)
+- `zcashlc_create_to_address` now takes the minimum number of confirmations
+  used to filter notes to spend as an argument.
 
 ## Removed
 - `zcashlc_derive_shielded_address_from_seed`
@@ -25,6 +33,6 @@
 - `zcashlc_derive_transparent_private_key_from_seed`
 - `zcashlc_derive_unified_viewing_keys_from_seed`
 
-# 0.0.3 
--  [#13] Migrate to `zcash/librustzcash` revision with NU5 awareness (#20)
-This enables mobile wallets to send transactions after NU5 activation.
+# 0.0.3
+- [#13] Migrate to `zcash/librustzcash` revision with NU5 awareness (#20)
+  This enables mobile wallets to send transactions after NU5 activation.

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -766,13 +766,14 @@ pub extern "C" fn zcashlc_get_verified_balance(
     db_data_len: usize,
     account: i32,
     network_id: u32,
+    min_confirmations: u32,
 ) -> i64 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
         let db_data = wallet_db(db_data, db_data_len, network)?;
         if account >= 0 {
             (&db_data)
-                .get_target_and_anchor_heights(ANCHOR_OFFSET)
+                .get_target_and_anchor_heights(min_confirmations)
                 .map_err(|e| format_err!("Error while fetching anchor height: {}", e))
                 .and_then(|opt_anchor| {
                     opt_anchor
@@ -800,6 +801,7 @@ pub extern "C" fn zcashlc_get_verified_transparent_balance(
     db_data_len: usize,
     address: *const c_char,
     network_id: u32,
+    min_confirmations: u32,
 ) -> i64 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
@@ -807,7 +809,7 @@ pub extern "C" fn zcashlc_get_verified_transparent_balance(
         let addr = unsafe { CStr::from_ptr(address).to_str()? };
         let taddr = TransparentAddress::decode(&network, &addr).unwrap();
         let amount = (&db_data)
-            .get_target_and_anchor_heights(ANCHOR_OFFSET)
+            .get_target_and_anchor_heights(min_confirmations)
             .map_err(|e| format_err!("Error while fetching anchor height: {}", e))
             .and_then(|opt_anchor| {
                 opt_anchor
@@ -846,7 +848,7 @@ pub extern "C" fn zcashlc_get_total_transparent_balance(
         let addr = unsafe { CStr::from_ptr(address).to_str()? };
         let taddr = TransparentAddress::decode(&network, &addr).unwrap();
         let amount = (&db_data)
-            .get_target_and_anchor_heights(ANCHOR_OFFSET)
+            .get_target_and_anchor_heights(0u32)
             .map_err(|e| format_err!("Error while fetching anchor height: {}", e))
             .and_then(|opt_anchor| {
                 opt_anchor
@@ -1204,6 +1206,7 @@ pub extern "C" fn zcashlc_create_to_address(
     output_params: *const u8,
     output_params_len: usize,
     network_id: u32,
+    min_confirmations: u32,
 ) -> i64 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
@@ -1266,7 +1269,7 @@ pub extern "C" fn zcashlc_create_to_address(
             value,
             memo,
             OvkPolicy::Sender,
-            ANCHOR_OFFSET,
+            min_confirmations,
         )
         .map_err(|e| format_err!("Error while sending funds: {}", e))
     });


### PR DESCRIPTION
Allow the caller to supply explicitly the number of confirmations required for TXOs when querying balances or sending funds.

Fixes #8
Fixes #9