### PR TITLE
Remove Spending key from `shield_funds`

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -540,7 +540,7 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -549,7 +549,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1978,7 +1978,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "bech32",
  "bs58",
@@ -1989,7 +1989,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "base64",
  "bech32",
@@ -2016,14 +2016,14 @@ dependencies = [
  "time",
  "tracing",
  "zcash_address",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "bech32",
  "bs58",
@@ -2046,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2078,7 +2078,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "aes",
  "bip0039",
@@ -2109,13 +2109,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.7.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f800f9f1446850e5009f88a16ed84ea19d573faf#f800f9f1446850e5009f88a16ed84ea19d573faf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -37,10 +37,10 @@ lto = true
 # We also need zcash_client_backend and zcash_client_sqlite, which haven't been published
 # with NU5 updates yet.
 [patch.crates-io]
-zcash_client_backend = { git = 'https://github.com/zcash/librustzcash.git', rev='f800f9f1446850e5009f88a16ed84ea19d573faf' }
-zcash_client_sqlite = { git = 'https://github.com/zcash/librustzcash.git', rev='f800f9f1446850e5009f88a16ed84ea19d573faf' }
-zcash_primitives = { git = 'https://github.com/zcash/librustzcash.git', rev='f800f9f1446850e5009f88a16ed84ea19d573faf' }
-zcash_proofs = { git = 'https://github.com/zcash/librustzcash.git', rev='f800f9f1446850e5009f88a16ed84ea19d573faf' }
+zcash_client_backend = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
+zcash_client_sqlite = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
+zcash_primitives = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
+zcash_proofs = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
 
 [features]
 mainnet = ["zcash_client_sqlite/mainnet"]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1809,8 +1809,6 @@ pub extern "C" fn zcashlc_derive_transparent_address_from_account_private_key(
 ///   documentation of pointer::offset.
 /// - `xprv` must be non-null and must point to a null-terminated UTF-8 string representing
 ///   a Base58-encoded transparent spending key.
-/// - `extsk` must be non-null and must point to a null-terminated UTF-8 string representing
-///   a Bech32-encoded Sapling extended spending key for the given network.
 /// - `spend_params` must be non-null and valid for reads for `spend_params_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be the Sapling spend proving parameters.
 /// - The memory referenced by `spend_params` must not be mutated for the duration of the function call.
@@ -1827,7 +1825,6 @@ pub extern "C" fn zcashlc_shield_funds(
     db_data_len: usize,
     account: i32,
     xprv: *const c_char,
-    extsk: *const c_char,
     memo: *const c_char,
     spend_params: *const u8,
     spend_params_len: usize,
@@ -1848,7 +1845,6 @@ pub extern "C" fn zcashlc_shield_funds(
             return Err(format_err!("account argument must be positive"));
         };
         let xprv_str = unsafe { CStr::from_ptr(xprv) }.to_str()?;
-        let extsk = unsafe { CStr::from_ptr(extsk) }.to_str()?;
         let memo = unsafe { CStr::from_ptr(memo) }.to_str()?;
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
@@ -1864,11 +1860,6 @@ pub extern "C" fn zcashlc_shield_funds(
         };
         let sk = legacy::keys::AccountPrivKey::from_extended_privkey(xprv.extended_key);
 
-        let extfvk =
-            decode_extended_spending_key(network.hrp_sapling_extended_spending_key(), extsk)
-                .map(|extsk| ExtendedFullViewingKey::from(&extsk))
-                .map_err(|e| format_err!("Invalid ExtendedSpendingKey: {}", e))?;
-
         let memo = Memo::from_str(memo).map_err(|_| format_err!("Invalid memo"))?;
         let memo_bytes = MemoBytes::from(memo);
         shield_transparent_funds(
@@ -1876,7 +1867,6 @@ pub extern "C" fn zcashlc_shield_funds(
             &network,
             LocalTxProver::new(spend_params, output_params),
             &sk,
-            &extfvk,
             AccountId::from(account),
             &memo_bytes,
             ANCHOR_OFFSET,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -843,6 +843,30 @@ fn is_valid_transparent_address(address: &str, network: &Network) -> bool {
     }
 }
 
+/// Returns true when the provided key decodes to a valid Sapling extended spending key for the
+/// specified network, false in any other case.
+///
+/// # Safety
+///
+/// - `extsk` must be non-null and must point to a null-terminated UTF-8 string.
+/// - The memory referenced by `extsk` must not be mutated for the duration of the function call.
+#[no_mangle]
+pub extern "C" fn zcashlc_is_valid_sapling_extended_spending_key(
+    extsk: *const c_char,
+    network_id: u32,
+) -> bool {
+    let res = catch_panic(|| {
+        let network = parse_network(network_id)?;
+        let extsk = unsafe { CStr::from_ptr(extsk).to_str()? };
+
+        Ok(
+            decode_extended_spending_key(network.hrp_sapling_extended_spending_key(), extsk)
+                .is_ok(),
+        )
+    });
+    unwrap_exc_or(res, false)
+}
+
 /// Returns true when the provided key decodes to a valid Sapling extended full viewing key for the
 /// specified network, false in any other case.
 ///


### PR DESCRIPTION
Remove Spending key from `shield_funds` and use Sapling extended full viewing key instead.

This is moving work forward to ultimately use UnifiedFullViewingKey from the db and only requiring account priv key as a parameter