### PR TITLE
Use unified spending keys instead of Sapling extended spending keys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ IMPORTANT NOTE: the binary representation of a unified spending key may be
 cached, but may become invalid and require re-derivation from seed to use as
 input to any of the relevant APIs in the future, in the case that the
 representation of the spending key changes or new types of spending authority
-are recognized.  The binary representation of unified spending keys should be
-handled with the same level of care and be treated as requiring the same level
-of secure storage as the wallet seed itself.
+are recognized.  Spending keys give irrevocable spend authority over
+a specific account.  Clients that choose to store the binary representation
+of unified spending keys locally on device, should handle them with the 
+same level of care and secure storage policies as the wallet seed itself. 
 
 ## Added
 - `zcashlc_create_account` provides new account creation functionality.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,99 @@
 # Unreleased
+
+Unified spending keys are now used in all places where spending authority
+is required, both for performing spends of shielded funds and for shielding
+transparent funds. Unified spending keys are represented as opaque arrays
+of bytes, and FFI methods are provided to permit derivation of viewing keys
+from the binary unified spending key representation.
+
+IMPORTANT NOTE: the binary representation of a unified spending key may be
+cached, but may become invalid and require re-derivation from seed to use as
+input to any of the relevant APIs in the future, in the case that the
+representation of the spending key changes or new types of spending authority
+are recognized.  The binary representation of unified spending keys should be
+handled with the same level of care and be treated as requiring the same level
+of secure storage as the wallet seed itself.
+
 ## Added
+- `zcashlc_create_account` provides new account creation functionality.
+  This is now the preferred API for the creation of new spend authorities
+  within the wallet; `zcashlc_init_accounts_table_with_keys` remains available
+  but should only be used if it is necessary to add multiple accounts at once,
+  such as when restoring a wallet from seed where multiple accounts had been
+  previously derived.
+
+Key derivation API:
+- `zcashlc_derive_spending_key`
+- `zcashlc_spending_key_to_full_viewing_key`
+
+Address retrieval, derivation, and verification API:
+- `zcashlc_get_current_address`
+- `zcashlc_get_next_available_address`
+- `zcashlc_get_sapling_receiver_for_unified_address`
+- `zcashlc_get_transparent_receiver_for_unified_address`
 - `zcashlc_is_valid_unified_address`
 - `zcashlc_is_valid_unified_full_viewing_key`
-- `zcashlc_derive_transparent_account_private_key_from_seed`
-- `zcashlc_derive_transparent_address_from_account_private_key`
-- `zcashlc_derive_unified_address_from_seed`
-- `zcashlc_derive_unified_address_from_viewing_key`
-- `zcashlc_derive_unified_full_viewing_keys_from_seed`
+
+New memo access API:
 - `zcashlc_get_received_memo`
 - `zcashlc_get_sent_memo`
 
 ## Changed
+- `zcashlc_create_to_address` now has been changed as follows:
+  - it no longer takes the string encoding of a Sapling extended spending key
+    as spend authority; instead, it takes the binary encoded form of a unified
+    spending key as returned by `zcashlc_create_account` or 
+    `zcashlc_derive_spending_key`. See the note above.
+  - it now takes the minimum number of confirmations used to filter notes to
+    spend as an argument.
+  - the memo argument is now passed as a potentially-null pointer to an
+    `[u8; 512]` instead of a C string.
+- `zcashlc_shield_funds` has been changed as follows:
+  - it no longer takes the transparent spending key for a single P2PKH address
+    as spend authority; instead, it takes the binary encoded form of a unified
+    spending key as returned by `zcashlc_create_account`
+    or `zcashlc_derive_spending_key`. See the note above.
+  - the memo argument is now passed as a potentially-null pointer to an
+    `[u8; 512]` instead of a C string.
+  - it no longer takes a destination address; instead, the internal shielding
+    address is automatically derived from the account ID.
 - Various changes have been made to correctly implement ZIP 316:
   - `FFIUnifiedViewingKey` now stores an account ID and the encoding of a
     ZIP 316 Unified Full Viewing Key.
   - `zcashlc_init_accounts_table_with_keys` now takes a slice of ZIP 316 UFVKs.
 - `zcashlc_put_utxo` no longer has an `address_str` argument (the address is
   instead inferred from the script).
-- `zcashlc_shield_funds` now takes the transparent account private key as an
-  argument instead of the transparent spending key for a single P2PKH address.
 - `zcashlc_get_verified_balance` now takes the minimum number of confirmations
   used to filter received notes as an argument.
 - `zcashlc_get_verified_transparent_balance` now takes the minimum number of
   confirmations used to filter received notes as an argument.
 - `zcashlc_get_total_transparent_balance` now returns a balance that includes
   all UTXOs up to those in the latest block (i.e. those with 0 confirmations.)
-- `zcashlc_create_to_address` now takes the minimum number of confirmations
-  used to filter notes to spend as an argument. Also, the memo argument is
-  now passed as a potentially-null pointer to an `[u8; 512]` instead of a
-  C string.
 
 ## Removed
-- `zcashlc_derive_shielded_address_from_seed`
-- `zcashlc_derive_shielded_address_from_viewing_key`
-- `zcashlc_derive_transparent_address_from_secret_key`
+
+The following spending key derivation APIs have been removed and replaced by
+`zcashlc_derive_spending_key`:
+- `zcashlc_derive_extended_spending_key`
 - `zcashlc_derive_transparent_private_key_from_seed`
+- `zcashlc_derive_transparent_account_private_key_from_seed`
+
+The following viewing key APIs have been removed and replaced by
+`zcashlc_spending_key_to_full_viewing_key`:
+- `zcashlc_derive_extended_full_viewing_key`
+- `zcashlc_derive_shielded_address_from_viewing_key`
 - `zcashlc_derive_unified_viewing_keys_from_seed`
+
+The following address derivation APIs have been removed in favor of
+`zcashlc_get_current_address` and `zcashlc_get_next_available_address`:
+- `zcashlc_get_address`
+- `zcashlc_derive_shielded_address_from_seed`
+- `zcashlc_derive_transparent_address_from_secret_key`
+- `zcashlc_derive_transparent_address_from_seed`
+- `zcashlc_derive_transparent_address_from_public_key`
+
+- `zcashlc_init_accounts_table` has been removed in favor of
+  `zcashlc_create_account`
 
 # 0.0.3
 - [#13] Migrate to `zcash/librustzcash` revision with NU5 awareness (#20)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b613b8e1e3cf911a086f53f03bf286f52fd7a7258e4fa606f0ef220d39d8877"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -35,7 +35,7 @@ dependencies = [
  "cfg-if",
  "cipher",
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -102,12 +102,6 @@ name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
-name = "base58"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
 
 [[package]]
 name = "base64"
@@ -204,23 +198,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding 0.1.5",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -229,7 +211,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -238,17 +220,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cb03d1bed155d89dce0f845b7899b18a9a163e148fd004e1c28421a783e2d8e"
 dependencies = [
- "block-padding 0.2.1",
+ "block-padding",
  "cipher",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
 ]
 
 [[package]]
@@ -284,12 +257,6 @@ name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -358,7 +325,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -454,7 +421,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "typenum",
 ]
 
@@ -464,7 +431,7 @@ version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "subtle",
 ]
 
@@ -479,20 +446,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
 ]
 
 [[package]]
@@ -540,7 +498,7 @@ checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -549,7 +507,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "blake2b_simd",
 ]
@@ -644,15 +602,6 @@ name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
 
 [[package]]
 name = "generic-array"
@@ -754,18 +703,6 @@ dependencies = [
  "rand_core",
  "ring",
  "secp256k1",
-]
-
-[[package]]
-name = "hdwallet-bitcoin"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "969c513e03167e65d4bb59f5c51ec3820210975044ad7f218ab801fc169760fa"
-dependencies = [
- "base58",
- "hdwallet",
- "hex",
- "ripemd160",
 ]
 
 [[package]]
@@ -885,8 +822,6 @@ dependencies = [
  "cbindgen",
  "failure",
  "ffi_helpers",
- "hdwallet",
- "hdwallet-bitcoin",
  "hex",
  "schemer",
  "secp256k1",
@@ -1019,12 +954,6 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
-name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -1136,7 +1065,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "048aeb476be11a4b6ca432ca569e375810de9294ae78f4774e78ea98a9246ede"
 dependencies = [
  "cpufeatures",
- "opaque-debug 0.3.0",
+ "opaque-debug",
  "universal-hash",
 ]
 
@@ -1342,17 +1271,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ripemd160"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad5112e0dbbb87577bfbc56c42450235e3012ce336e29c5befd7807bd626da4a"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
 name = "rusqlite"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,7 +1434,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -1841,7 +1759,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f214e8f697e925001e66ec2c6e37a4ef93f0f78c2eed7814394e10c62025b05"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array",
  "subtle",
 ]
 
@@ -1979,7 +1897,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "bech32",
  "bs58",
@@ -1990,12 +1908,13 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.5.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "base64",
  "bech32",
  "bls12_381",
  "bs58",
+ "byteorder",
  "crossbeam-channel",
  "ff",
  "group",
@@ -2012,24 +1931,27 @@ dependencies = [
  "rayon",
  "ripemd",
  "secp256k1",
+ "secrecy",
  "sha2 0.10.2",
  "subtle",
  "time",
  "tracing",
  "zcash_address",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af)",
+ "zcash_encoding",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "bech32",
  "bs58",
  "ff",
  "group",
+ "hdwallet",
  "jubjub",
  "protobuf",
  "rand_core",
@@ -2047,7 +1969,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2068,7 +1990,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2079,7 +2001,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.7.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "aes",
  "bip0039",
@@ -2110,13 +2032,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af)",
+ "zcash_note_encryption 0.1.0 (git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.7.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=8c00ca3b88d0fea880ccd731544ad312caa0e6af#8c00ca3b88d0fea880ccd731544ad312caa0e6af"
+source = "git+https://github.com/zcash/librustzcash.git?rev=3bc8627e2b15cae0fe0bcccf327c517f573c8a89#3bc8627e2b15cae0fe0bcccf327c517f573c8a89"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,16 +10,14 @@ build = "build.rs"
 [dependencies]
 failure = "0.1"
 ffi_helpers = "0.2"
-hdwallet = "0.3.1"
-hdwallet-bitcoin = "0.3"
 hex = "0.4"
 schemer = "0.2"
 secp256k1 = "0.21"
 secrecy = "0.8"
 
 zcash_address = { version = "0.1" }
-zcash_client_backend = { version = "0.5", features = ["transparent-inputs"] }
-zcash_client_sqlite = { version = "0.3", features = ["transparent-inputs"] }
+zcash_client_backend = { version = "0.5", features = ["transparent-inputs", "unstable"] }
+zcash_client_sqlite = { version = "0.3", features = ["transparent-inputs", "unstable"] }
 zcash_primitives = "0.7"
 zcash_proofs = "0.7"
 
@@ -38,11 +36,11 @@ lto = true
 # We also need zcash_client_backend and zcash_client_sqlite, which haven't been published
 # with NU5 updates yet.
 [patch.crates-io]
-zcash_address = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
-zcash_client_backend = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
-zcash_client_sqlite = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
-zcash_primitives = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
-zcash_proofs = { git = 'https://github.com/zcash/librustzcash.git', rev='8c00ca3b88d0fea880ccd731544ad312caa0e6af' }
+zcash_address = { git = 'https://github.com/zcash/librustzcash.git', rev='3bc8627e2b15cae0fe0bcccf327c517f573c8a89' }
+zcash_client_backend = { git = 'https://github.com/zcash/librustzcash.git', rev='3bc8627e2b15cae0fe0bcccf327c517f573c8a89' }
+zcash_client_sqlite = { git = 'https://github.com/zcash/librustzcash.git', rev='3bc8627e2b15cae0fe0bcccf327c517f573c8a89' }
+zcash_primitives = { git = 'https://github.com/zcash/librustzcash.git', rev='3bc8627e2b15cae0fe0bcccf327c517f573c8a89' }
+zcash_proofs = { git = 'https://github.com/zcash/librustzcash.git', rev='3bc8627e2b15cae0fe0bcccf327c517f573c8a89' }
 
 [features]
 mainnet = ["zcash_client_sqlite/mainnet"]


### PR DESCRIPTION
This also updates `zcashlc_create_to_address` to take a unified spending key for spending authority instead of a Sapling extended spending key.