### PR TITLE
`unsafe` annotations

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -163,7 +163,7 @@ pub extern "C" fn zcashlc_clear_last_error() {
 /// - The total size `seed_len` must be no larger than `isize::MAX`. See the safety documentation
 ///   of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_init_data_database(
+pub unsafe extern "C" fn zcashlc_init_data_database(
     db_data: *const u8,
     db_data_len: usize,
     seed: *const u8,
@@ -264,7 +264,7 @@ pub unsafe extern "C" fn zcashlc_free_binary_key(ptr: *mut FFIBinaryKey) {
 ///
 /// [ZIP 316]: https://zips.z.cash/zip-0316
 #[no_mangle]
-pub extern "C" fn zcashlc_create_account(
+pub unsafe extern "C" fn zcashlc_create_account(
     db_data: *const u8,
     db_data_len: usize,
     seed: *const u8,
@@ -373,7 +373,7 @@ pub unsafe extern "C" fn zcashlc_free_keys(ptr: *mut FFIEncodedKeys) {
 /// - The total size `ufvks_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_init_accounts_table_with_keys(
+pub unsafe extern "C" fn zcashlc_init_accounts_table_with_keys(
     db_data: *const u8,
     db_data_len: usize,
     ufvks_ptr: *mut FFIEncodedKey,
@@ -491,7 +491,7 @@ unsafe fn decode_usk(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when you are done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_spending_key_to_full_viewing_key(
+pub unsafe extern "C" fn zcashlc_spending_key_to_full_viewing_key(
     usk_ptr: *const u8,
     usk_len: usize,
     network_id: u32,
@@ -528,7 +528,7 @@ pub extern "C" fn zcashlc_spending_key_to_full_viewing_key(
 /// - The memory referenced by `sapling_tree_hex` must not be mutated for the duration of the
 ///   function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_init_blocks_table(
+pub unsafe extern "C" fn zcashlc_init_blocks_table(
     db_data: *const u8,
     db_data_len: usize,
     height: i32,
@@ -575,7 +575,7 @@ pub extern "C" fn zcashlc_init_blocks_table(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_current_address(
+pub unsafe extern "C" fn zcashlc_get_current_address(
     db_data: *const u8,
     db_data_len: usize,
     account: i32,
@@ -621,7 +621,7 @@ pub extern "C" fn zcashlc_get_current_address(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_next_available_address(
+pub unsafe extern "C" fn zcashlc_get_next_available_address(
     db_data: *const u8,
     db_data_len: usize,
     account: i32,
@@ -668,7 +668,7 @@ pub extern "C" fn zcashlc_get_next_available_address(
 /// - Call [`zcashlc_free_keys`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_list_transparent_receivers(
+pub unsafe extern "C" fn zcashlc_list_transparent_receivers(
     db_data: *const u8,
     db_data_len: usize,
     account_id: i32,
@@ -722,7 +722,7 @@ pub extern "C" fn zcashlc_list_transparent_receivers(
 /// - Call [`zcashlc_free_typecodes`] to free the memory associated with the returned
 ///   pointer when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_typecodes_for_unified_address_receivers(
+pub unsafe extern "C" fn zcashlc_get_typecodes_for_unified_address_receivers(
     ua: *const c_char,
     len_ret: *mut usize,
 ) -> *mut u32 {
@@ -790,7 +790,7 @@ impl zcash_address::TryFromRawAddress for UnifiedAddressParser {
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_transparent_receiver_for_unified_address(
+pub unsafe extern "C" fn zcashlc_get_transparent_receiver_for_unified_address(
     ua: *const c_char,
 ) -> *mut c_char {
     let res = catch_panic(|| {
@@ -831,7 +831,7 @@ pub extern "C" fn zcashlc_get_transparent_receiver_for_unified_address(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_sapling_receiver_for_unified_address(
+pub unsafe extern "C" fn zcashlc_get_sapling_receiver_for_unified_address(
     ua: *const c_char,
 ) -> *mut c_char {
     let res = catch_panic(|| {
@@ -866,7 +866,7 @@ pub extern "C" fn zcashlc_get_sapling_receiver_for_unified_address(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_shielded_address(
+pub unsafe extern "C" fn zcashlc_is_valid_shielded_address(
     address: *const c_char,
     network_id: u32,
 ) -> bool {
@@ -973,7 +973,7 @@ impl TryFromAddress for AddressMetadata {
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_address_metadata(
+pub unsafe extern "C" fn zcashlc_get_address_metadata(
     address: *const c_char,
     network_id_ret: *mut u32,
     addr_kind_ret: *mut u32,
@@ -1018,7 +1018,7 @@ pub extern "C" fn zcashlc_get_address_metadata(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_transparent_address(
+pub unsafe extern "C" fn zcashlc_is_valid_transparent_address(
     address: *const c_char,
     network_id: u32,
 ) -> bool {
@@ -1048,7 +1048,7 @@ fn is_valid_transparent_address(address: &str, network: &Network) -> bool {
 /// - `extsk` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `extsk` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_sapling_extended_spending_key(
+pub unsafe extern "C" fn zcashlc_is_valid_sapling_extended_spending_key(
     extsk: *const c_char,
     network_id: u32,
 ) -> bool {
@@ -1072,7 +1072,7 @@ pub extern "C" fn zcashlc_is_valid_sapling_extended_spending_key(
 /// - `key` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `key` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_viewing_key(key: *const c_char, network_id: u32) -> bool {
+pub unsafe extern "C" fn zcashlc_is_valid_viewing_key(key: *const c_char, network_id: u32) -> bool {
     let res =
         catch_panic(|| {
             let network = parse_network(network_id)?;
@@ -1096,7 +1096,7 @@ pub extern "C" fn zcashlc_is_valid_viewing_key(key: *const c_char, network_id: u
 /// - The memory referenced by `ufvk` must not be mutated for the duration of the
 ///   function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_unified_full_viewing_key(
+pub unsafe extern "C" fn zcashlc_is_valid_unified_full_viewing_key(
     ufvk: *const c_char,
     network_id: u32,
 ) -> bool {
@@ -1118,7 +1118,7 @@ pub extern "C" fn zcashlc_is_valid_unified_full_viewing_key(
 /// - The memory referenced by `address` must not be mutated for the duration of the
 ///   function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_is_valid_unified_address(
+pub unsafe extern "C" fn zcashlc_is_valid_unified_address(
     address: *const c_char,
     network_id: u32,
 ) -> bool {
@@ -1151,7 +1151,7 @@ fn is_valid_unified_address(address: &str, network: &Network) -> bool {
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_balance(
+pub unsafe extern "C" fn zcashlc_get_balance(
     db_data: *const u8,
     db_data_len: usize,
     account: i32,
@@ -1194,7 +1194,7 @@ pub extern "C" fn zcashlc_get_balance(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_verified_balance(
+pub unsafe extern "C" fn zcashlc_get_verified_balance(
     db_data: *const u8,
     db_data_len: usize,
     account: i32,
@@ -1240,7 +1240,7 @@ pub extern "C" fn zcashlc_get_verified_balance(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_verified_transparent_balance(
+pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance(
     db_data: *const u8,
     db_data_len: usize,
     address: *const c_char,
@@ -1291,7 +1291,7 @@ pub extern "C" fn zcashlc_get_verified_transparent_balance(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_verified_transparent_balance_for_account(
+pub unsafe extern "C" fn zcashlc_get_verified_transparent_balance_for_account(
     db_data: *const u8,
     db_data_len: usize,
     network_id: u32,
@@ -1364,7 +1364,7 @@ pub extern "C" fn zcashlc_get_verified_transparent_balance_for_account(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_total_transparent_balance(
+pub unsafe extern "C" fn zcashlc_get_total_transparent_balance(
     db_data: *const u8,
     db_data_len: usize,
     address: *const c_char,
@@ -1413,7 +1413,7 @@ pub extern "C" fn zcashlc_get_total_transparent_balance(
 /// - `address` must be non-null and must point to a null-terminated UTF-8 string.
 /// - The memory referenced by `address` must not be mutated for the duration of the function call.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_total_transparent_balance_for_account(
+pub unsafe extern "C" fn zcashlc_get_total_transparent_balance_for_account(
     db_data: *const u8,
     db_data_len: usize,
     network_id: u32,
@@ -1472,7 +1472,7 @@ pub extern "C" fn zcashlc_get_total_transparent_balance_for_account(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_received_memo_as_utf8(
+pub unsafe extern "C" fn zcashlc_get_received_memo_as_utf8(
     db_data: *const u8,
     db_data_len: usize,
     id_note: i64,
@@ -1512,20 +1512,22 @@ pub extern "C" fn zcashlc_get_received_memo_as_utf8(
 ///   documentation of pointer::offset.
 /// - `memo_bytes_ret` must be non-null and must point to an allocated 512-byte region of memory.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_received_memo(
+pub unsafe extern "C" fn zcashlc_get_received_memo(
     db_data: *const u8,
     db_data_len: usize,
     id_note: i64,
     memo_bytes_ret: *mut u8,
     network_id: u32,
 ) -> bool {
-    zcashlc_get_memo(
-        db_data,
-        db_data_len,
-        NoteId::ReceivedNoteId(id_note),
-        memo_bytes_ret,
-        network_id,
-    )
+    unsafe {
+        zcashlc_get_memo(
+            db_data,
+            db_data_len,
+            NoteId::ReceivedNoteId(id_note),
+            memo_bytes_ret,
+            network_id,
+        )
+    }
 }
 
 /// Returns the memo for a note by copying the corresponding bytes to the received
@@ -1540,7 +1542,7 @@ pub extern "C" fn zcashlc_get_received_memo(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 /// - `memo_bytes_ret` must be non-null and must point to an allocated 512-byte region of memory.
-fn zcashlc_get_memo(
+unsafe fn zcashlc_get_memo(
     db_data: *const u8,
     db_data_len: usize,
     note_id: NoteId,
@@ -1578,7 +1580,7 @@ fn zcashlc_get_memo(
 /// - Call [`zcashlc_string_free`] to free the memory associated with the returned pointer
 ///   when done using it.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_sent_memo_as_utf8(
+pub unsafe extern "C" fn zcashlc_get_sent_memo_as_utf8(
     db_data: *const u8,
     db_data_len: usize,
     id_note: i64,
@@ -1618,20 +1620,22 @@ pub extern "C" fn zcashlc_get_sent_memo_as_utf8(
 ///   documentation of pointer::offset.
 /// - `memo_bytes_ret` must be non-null and must point to an allocated 512-byte region of memory.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_sent_memo(
+pub unsafe extern "C" fn zcashlc_get_sent_memo(
     db_data: *const u8,
     db_data_len: usize,
     id_note: i64,
     memo_bytes_ret: *mut u8,
     network_id: u32,
 ) -> bool {
-    zcashlc_get_memo(
-        db_data,
-        db_data_len,
-        NoteId::SentNoteId(id_note),
-        memo_bytes_ret,
-        network_id,
-    )
+    unsafe {
+        zcashlc_get_memo(
+            db_data,
+            db_data_len,
+            NoteId::SentNoteId(id_note),
+            memo_bytes_ret,
+            network_id,
+        )
+    }
 }
 
 /// Checks that the scanned blocks in the data database, when combined with the recent
@@ -1666,7 +1670,7 @@ pub extern "C" fn zcashlc_get_sent_memo(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_validate_combined_chain(
+pub unsafe extern "C" fn zcashlc_validate_combined_chain(
     db_cache: *const u8,
     db_cache_len: usize,
     db_data: *const u8,
@@ -1712,7 +1716,7 @@ pub extern "C" fn zcashlc_validate_combined_chain(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_get_nearest_rewind_height(
+pub unsafe extern "C" fn zcashlc_get_nearest_rewind_height(
     db_data: *const u8,
     db_data_len: usize,
     height: i32,
@@ -1764,7 +1768,7 @@ pub extern "C" fn zcashlc_get_nearest_rewind_height(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_rewind_to_height(
+pub unsafe extern "C" fn zcashlc_rewind_to_height(
     db_data: *const u8,
     db_data_len: usize,
     height: i32,
@@ -1814,7 +1818,7 @@ pub extern "C" fn zcashlc_rewind_to_height(
 /// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_scan_blocks(
+pub unsafe extern "C" fn zcashlc_scan_blocks(
     db_cache: *const u8,
     db_cache_len: usize,
     db_data: *const u8,
@@ -1861,7 +1865,7 @@ pub extern "C" fn zcashlc_scan_blocks(
 /// - The total size `script_bytes_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_put_utxo(
+pub unsafe extern "C" fn zcashlc_put_utxo(
     db_data: *const u8,
     db_data_len: usize,
     txid_bytes: *const u8,
@@ -1923,7 +1927,7 @@ pub extern "C" fn zcashlc_put_utxo(
 /// - The total size `tx_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_decrypt_and_store_transaction(
+pub unsafe extern "C" fn zcashlc_decrypt_and_store_transaction(
     db_data: *const u8,
     db_data_len: usize,
     tx: *const u8,
@@ -1990,7 +1994,7 @@ pub extern "C" fn zcashlc_decrypt_and_store_transaction(
 /// - The total size `output_params_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_create_to_address(
+pub unsafe extern "C" fn zcashlc_create_to_address(
     db_data: *const u8,
     db_data_len: usize,
     usk_ptr: *const u8,
@@ -2153,7 +2157,7 @@ pub unsafe extern "C" fn zcashlc_string_free(s: *mut c_char) {
 /// - The total size `output_params_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
-pub extern "C" fn zcashlc_shield_funds(
+pub unsafe extern "C" fn zcashlc_shield_funds(
     db_data: *const u8,
     db_data_len: usize,
     usk_ptr: *const u8,


### PR DESCRIPTION
This enables `deny(unsafe_op_in_unsafe_fn)` globally and adds `unsafe` annotations as necessary. fixes #65