### PR TITLE
Implement FsBlockDb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 FsBlock Db implementation and removal of BlockBb cache.
 
-Implement `zcashlc_write_block_metadata`, `zcashlc_free_block_meta, `zcashlc_free_blocks_meta`
+Implement `zcashlc_init_block_metadata_db`, `zcashlc_write_block_metadata`, `zcashlc_free_block_meta, `zcashlc_free_blocks_meta`
 
 Declare `repr(C)` structs for FFI:
  - `FFIBlockMeta`: a block metadata row

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-# unreleased
+# unreleased 
+
+FsBlock Db implementation and removal of BlockBb cache.
+
+
+Implement `zcashlc_write_block_metadata`, `zcashlc_free_block_meta, `zcashlc_free_blocks_meta`
+
+Declare `repr(C)` structs for FFI:
+ - `FFIBlockMeta`: a block metadata row
+ - `FFIBlocksMeta`: a structure that holds an array of `FFIBlockMeta`
 
 - [#78] removing cocoapods support
 # 0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Declare `repr(C)` structs for FFI:
 
 expose shielding threshold for `shield_funds`
 
+- [#81] Adopt latest crate versions
+Bumped dependencies to `zcash_primitives 0.10`, `zcash_client_backend 0.7`,
+`zcash_proofs 0.10`, `zcash_client_sqlite 0.5.0`
+
+this adds support for `min_confirmations` on `shield_funds` and `shielding_threshold`.
 - [#78] removing cocoapods support
 # 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,14 @@
 
 FsBlock Db implementation and removal of BlockBb cache.
 
-
 Implement `zcashlc_write_block_metadata`, `zcashlc_free_block_meta, `zcashlc_free_blocks_meta`
 
 Declare `repr(C)` structs for FFI:
  - `FFIBlockMeta`: a block metadata row
  - `FFIBlocksMeta`: a structure that holds an array of `FFIBlockMeta`
+
+
+expose shielding threshold for `shield_funds`
 
 - [#78] removing cocoapods support
 # 0.1.1

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
+source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1517,18 +1517,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=c1761daae2e740389ca9310cc09049e38d57fa85#c1761daae2e740389ca9310cc09049e38d57fa85"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1030,9 +1030,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
 name = "opaque-debug"
@@ -1517,18 +1517,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -965,9 +965,9 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "e5507769c4919c998e69e49c839d9dc6e693ede4cc4290d6ad8b41d4f09c548c"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -1021,9 +1021,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
+checksum = "2b8c786513eb403643f2a88c244c2aaa270ef2153f55094587d0c48a3cf22a83"
 dependencies = [
  "memchr",
 ]
@@ -1160,9 +1160,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
+checksum = "e97e3215779627f01ee256d2fad52f3d95e8e1c11e9fc6fd08f7cd455d5d5c78"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1185,9 +1185,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "21dc42e00223fc37204bd4aa177e69420c604ca4a183209a8f9de30c6d934698"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1195,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
+checksum = "a3f8ad728fb08fe212df3c05169e940fbb6d9d16a877ddde14644a983ba2012e"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "8bda8c0881ea9f722eb9629376db3d0b903b462477c1aafcb0566610ac28ac5d"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1230,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
+checksum = "a5e0526209433e96d83d750dd81a99118edbc55739e7e61a46764fd2ad537788"
 dependencies = [
  "bytes",
  "prost",
@@ -1360,9 +1360,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "regex-syntax",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
+source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=399313db0a3671c6b4b56f28841507fed6eb3ed6#399313db0a3671c6b4b56f28841507fed6eb3ed6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe#7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2047,7 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "bech32",
  "bs58",
@@ -2058,7 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2132,7 +2132,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "chacha20",
  "chacha20poly1305",
@@ -2144,7 +2144,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf)",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf#ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf"
+source = "git+https://github.com/zcash/librustzcash.git?rev=7cbb2778843832e53b26470d95d28a4e73c93205#7cbb2778843832e53b26470d95d28a4e73c93205"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -524,7 +524,8 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -533,7 +534,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1065,7 +1067,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
@@ -2047,7 +2049,8 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804268e702b664fc09d3e2ce82786d0addf4ae57ba6976469be63e09066bf9f7"
 dependencies = [
  "bech32",
  "bs58",
@@ -2057,8 +2060,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.6.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54c054a049b69506098b5fa44830d4196a8bbea7bee9762718f251f1c4d8277e"
 dependencies = [
  "base64",
  "bech32",
@@ -2082,14 +2086,15 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e)",
+ "zcash_note_encryption",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.4.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df5fd0152fd7207100581918ce772348266f1173cfb0f0a3f3900ac824cacb5"
 dependencies = [
  "bs58",
  "group",
@@ -2110,7 +2115,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2130,21 +2136,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "zcash_note_encryption"
-version = "0.2.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
-dependencies = [
- "chacha20",
- "chacha20poly1305",
- "cipher 0.4.3",
- "rand_core",
- "subtle",
-]
-
-[[package]]
 name = "zcash_primitives"
-version = "0.9.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6879bd4026d9269a41ca91858f453b523f30824288248148211e1cab23b3e0d"
 dependencies = [
  "aes",
  "bip0039",
@@ -2173,13 +2168,14 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e)",
+ "zcash_note_encryption",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e#a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28ca180a8138ae6e2de2b88573ed19dd57798f42a79a00d992b4d727132c7081"
 dependencies = [
  "bellman",
  "blake2b_simd",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -61,9 +61,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "arrayref"
@@ -83,7 +83,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
 ]
@@ -96,9 +96,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -117,9 +117,9 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64ct"
@@ -244,9 +244,9 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "bls12_381"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62250ece575fa9b22068b3a8d59586f01d426dd7785522efd97632959e71c986"
+checksum = "a3c196a77437e7cc2fb515ce413a6401291578b5afc8ecb29a3c7ab957f05941"
 dependencies = [
  "ff",
  "group",
@@ -266,9 +266,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.11.0"
+version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
 
 [[package]]
 name = "byteorder"
@@ -278,9 +278,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
+checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
 
 [[package]]
 name = "cbindgen"
@@ -302,9 +302,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.11"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.12"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
 ]
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adfbc57365a37acbd2ebf2b64d7e69bb766e2fea813521ed536f5d0520dcf86c"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer 0.10.3",
  "crypto-common",
@@ -524,8 +524,7 @@ checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 [[package]]
 name = "equihash"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab579d7cf78477773b03e80bc2f89702ef02d7112c711d54ca93dcdce68533d5"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -534,8 +533,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a83e8d7fd0c526af4aad893b7c9fe41e2699ed8a776a6c74aecdeafe05afc75"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "blake2b_simd",
 ]
@@ -585,9 +583,9 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df689201f395c6b90dfe87127685f8dbfc083a5e779e613575d8bd7314300c3e"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
  "bitvec",
  "rand_core",
@@ -643,9 +641,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "libc",
@@ -654,9 +652,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "dec7af912d60cdbd3677c1af9352ebae6fb8394d165568a2234df0fa00f87793"
 
 [[package]]
 name = "group"
@@ -764,6 +762,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,9 +797,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
@@ -827,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
@@ -862,15 +869,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "292a948cd991e376cf75541fe5b97a1081d713c618b4f1b9500f8844e49eb565"
+checksum = "348108ab3fba42ec82ff6e9564fc4ca0247bdccdc68dd8af9764bbc79c3c8ffb"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -919,9 +926,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -943,9 +950,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -1004,28 +1011,28 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "239da7f290cfa979f43f85a8efeee9a8a76d0827c356d37f9d3d7254d6b537fb"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
+checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "opaque-debug"
@@ -1058,7 +1065,7 @@ dependencies = [
  "serde",
  "subtle",
  "tracing",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1130,9 +1137,9 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "poly1305"
@@ -1147,15 +1154,15 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c142c0e46b57171fe0c528bee8c5b7569e80f0c17e377cd0e30ea57dbc11bb51"
+checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1163,24 +1170,24 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.19"
+version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.46"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399c3c31cdec40583bb68f0b18403400d01ec4289c383aa047560439952c4dd7"
+checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1188,9 +1195,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f835c582e6bd972ba8347313300219fed5bfa52caf175298d860b61ff6069bb"
+checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
 dependencies = [
  "bytes",
  "heck 0.4.0",
@@ -1199,18 +1206,20 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
+ "prettyplease",
  "prost",
  "prost-types",
  "regex",
+ "syn",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7345d5f0e08c0536d7ac7229952590239e77abf0a0100a1b1d890add6ea96364"
+checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
 dependencies = [
  "anyhow",
  "itertools",
@@ -1221,9 +1230,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.1"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfaa718ad76a44b3415e6c4d53b17c8f99160dcb3a99b10470fce8ad43f6e3e"
+checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
 dependencies = [
  "bytes",
  "prost",
@@ -1231,9 +1240,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -1276,21 +1285,19 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1353,18 +1360,18 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.27"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "remove_dir_all"
@@ -1396,7 +1403,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd124222d17ad93a644ed9d011a40f4fb64aa54275c08cc216524a9ea82fb09f"
 dependencies = [
- "digest 0.10.5",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1433,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "schemer"
@@ -1510,18 +1517,18 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1530,9 +1537,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.86"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41feea4228a6f1cd09ec7a3593a682276702cd67b5273544757dae23c096f074"
+checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
 dependencies = [
  "itoa",
  "ryu",
@@ -1657,9 +1664,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1709,18 +1716,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1782,18 +1789,18 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "toml"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82e1a7758622a465f8cee077614c73484dac5b836c02ff6a40d5d1010324d7"
+checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c6fd7c2581e36d63388a9e04c350c21beb7a8b059580b2e93993c526899ddc"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
 dependencies = [
  "prettyplease",
  "proc-macro2",
@@ -1836,15 +1843,15 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "uint"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a45526d29728d135c2900b0d30573fe3ee79fceb12ef534c7bb30e810a91b601"
+checksum = "76f64bba2c53b04fcab63c01a7d7427eadc821e3bc48c34dc9ba29c501164b52"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -1854,9 +1861,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-normalization"
@@ -1903,9 +1910,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "uuid"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb41e78f93363bb2df8b0e86a2ca30eed7806ea16ea0c790d757cf93f79be83"
+checksum = "422ee0de9031b5b948b97a8fc04e3aa35230001a722ddd27943e0be31564ce4c"
 
 [[package]]
 name = "vcpkg"
@@ -2030,9 +2037,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "wyz"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
@@ -2040,8 +2047,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804268e702b664fc09d3e2ce82786d0addf4ae57ba6976469be63e09066bf9f7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "bech32",
  "bs58",
@@ -2052,8 +2058,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e90362fd61a41f694c072d8db0f8dd59a1fdc902cab3602c42e755d1b9882831"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "base64",
  "bech32",
@@ -2077,15 +2082,14 @@ dependencies = [
  "which",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d)",
  "zcash_primitives",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b1bfd170ee7e73b390dac2799ffbc8bb83724aa3e3cb24f5e83089c97afefd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "bs58",
  "group",
@@ -2106,8 +2110,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f03391b81727875efa6ac0661a20883022b6fba92365dc121c48fa9b00c5aac0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "byteorder",
  "nonempty",
@@ -2127,10 +2130,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_note_encryption"
+version = "0.2.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
+dependencies = [
+ "chacha20",
+ "chacha20poly1305",
+ "cipher 0.4.3",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9a45953c4ddd81d68f45920955707f45c8926800671f354dd13b97507edf28"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "aes",
  "bip0039",
@@ -2159,14 +2173,13 @@ dependencies = [
  "subtle",
  "zcash_address",
  "zcash_encoding",
- "zcash_note_encryption",
+ "zcash_note_encryption 0.2.0 (git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d)",
 ]
 
 [[package]]
 name = "zcash_proofs"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77381adc72286874e563ee36ba99953946abcbd195ada45440a2754ca823d407"
+source = "git+https://github.com/zcash/librustzcash.git?rev=c0875f80bff43cd4ac5b06359d97803f8a3b872d#c0875f80bff43cd4ac5b06359d97803f8a3b872d"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -2192,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -894,7 +894,7 @@ dependencies = [
 
 [[package]]
 name = "libzcashlc"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "cbindgen",
  "failure",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -38,3 +38,11 @@ lto = true
 [features]
 mainnet = ["zcash_client_sqlite/mainnet"]
 testnet = []
+
+[patch.crates-io]
+
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "c1761daae2e740389ca9310cc09049e38d57fa85" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ad2d2f1a8845c347a4d1af2a26b94d6f02622ecf" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7cbb2778843832e53b26470d95d28a4e73c93205" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libzcashlc"
-version = "0.1.0"
+version = "0.2.0"
 authors = [
     "Jack Grigg <jack@z.cash>",
     "Francisco Gindre <francisco@z.cash>",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "c0875f80bff43cd4ac5b06359d97803f8a3b872d" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "525a50ae4bdee66db670e0764f35204fe3153b3b" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,10 +19,10 @@ secp256k1 = "0.21"
 secrecy = "0.8"
 
 zcash_address = { version = "0.2" }
-zcash_client_backend = { version = "0.6.1", features = ["transparent-inputs", "unstable"] }
-zcash_client_sqlite = { version = "0.4.2", features = ["transparent-inputs", "unstable"] }
-zcash_primitives = "0.9.1"
-zcash_proofs = "0.9"
+zcash_client_backend = { version = "0.7.0", features = ["transparent-inputs", "unstable"] }
+zcash_client_sqlite = { version = "0.5.0", features = ["transparent-inputs", "unstable"] }
+zcash_primitives = "0.10.0"
+zcash_proofs = "0.10.0"
 
 [build-dependencies]
 cbindgen = "0.14"
@@ -38,11 +38,3 @@ lto = true
 [features]
 mainnet = ["zcash_client_sqlite/mainnet"]
 testnet = []
-
-[patch.crates-io]
-
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "a6f2a6c41b972ba7bbc697cb6a1ebc5e85657b7e" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -41,8 +41,8 @@ testnet = []
 
 [patch.crates-io]
 
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "399313db0a3671c6b4b56f28841507fed6eb3ed6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "7306b9d2a9ee04732b58a9b1f87f1c70db31f5fe" }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1949,6 +1949,17 @@ pub struct FFIBlockMeta {
     orchard_actions_count: u32,
 }
 
+/// # Safety
+/// Initializes the `FsBlockDb` sqlite database. Does nothing if already created
+///
+/// Returns true when successful, false otherwise. When false is returned caller 
+/// should check for errors.
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_init_block_metadata_db(
     fs_block_db_root: *const u8,
@@ -1968,6 +1979,24 @@ pub unsafe extern "C" fn zcashlc_init_block_metadata_db(
     unwrap_exc_or(res, false)
 }
 
+/// Writes the blocks provided in `blocks_meta` into the `BlockMeta` database
+/// 
+/// Returns true if the `blocks_meta` could be stored into the `FsBlockDb`. False
+/// otherwise. 
+/// 
+/// When false is returned caller should check for errors. 
+/// 
+/// # Safety
+///
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+/// - Block metadata represented in `blocks_meta` must be non-null. Caller must guarantee that the 
+/// memory reference by this pointer is not freed up, dereferenced or invalidated while this function
+/// is invoked.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_write_block_metadata(
     fs_block_db_root: *const u8,
@@ -2019,11 +2048,11 @@ pub unsafe extern "C" fn zcashlc_write_block_metadata(
 ///
 /// # Safety
 ///
-/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
-/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_rewind_fs_block_cache_to_height(

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -58,8 +58,6 @@ use zcash_primitives::{
 };
 use zcash_proofs::prover::LocalTxProver;
 
-const ANCHOR_OFFSET: u32 = 10;
-
 fn unwrap_exc_or<T>(exc: Result<T, ()>, def: T) -> T {
     match exc {
         Ok(value) => value,
@@ -2371,6 +2369,7 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
     output_params: *const u8,
     output_params_len: usize,
     network_id: u32,
+    min_confirmations: u32,
     use_zip317_fees: bool,
 ) -> i64 {
     let res = catch_panic(|| {
@@ -2441,7 +2440,7 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                ANCHOR_OFFSET,
+                min_confirmations,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         } else {
@@ -2459,7 +2458,7 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                ANCHOR_OFFSET,
+                min_confirmations,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1676,6 +1676,7 @@ pub unsafe extern "C" fn zcashlc_validate_combined_chain(
     fs_block_db_root_len: usize,
     db_data: *const u8,
     db_data_len: usize,
+    validate_limit: u32,
     network_id: u32,
 ) -> i32 {
     let res = catch_panic(|| {
@@ -1687,7 +1688,13 @@ pub unsafe extern "C" fn zcashlc_validate_combined_chain(
             .get_max_height_hash()
             .map_err(|e| format_err!("Error while validating chain: {}", e))?;
 
-        let val_res = validate_chain(&network, &block_db, validate_from);
+        let limit = if validate_limit == 0 {
+            None
+        } else {
+            Some(validate_limit)
+        };
+
+        let val_res = validate_chain(&block_db, validate_from, limit);
 
         if let Err(e) = val_res {
             match e {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,6 +4,8 @@ use failure::format_err;
 use ffi_helpers::panic::catch_panic;
 use schemer::MigratorError;
 use secrecy::Secret;
+use zcash_primitives::transaction::components::amount::NonNegativeAmount;
+
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{CStr, CString, OsStr};
@@ -12,7 +14,6 @@ use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::slice;
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
 use zcash_address::{
     self,
@@ -38,9 +39,8 @@ use zcash_client_backend::{
 #[allow(deprecated)]
 use zcash_client_sqlite::wallet::get_rewind_height;
 use zcash_client_sqlite::{
-    chain::{init::init_blockmeta_db, BlockMeta},
     wallet::init::{init_accounts_table, init_blocks_table, init_wallet_db, WalletMigrationError},
-    FsBlockDb, NoteId, WalletDb,
+    BlockDb, NoteId, WalletDb,
 };
 use zcash_primitives::consensus::Network::{MainNetwork, TestNetwork};
 use zcash_primitives::{
@@ -57,8 +57,6 @@ use zcash_primitives::{
     zip32::AccountId,
 };
 use zcash_proofs::prover::LocalTxProver;
-
-const ANCHOR_OFFSET: u32 = 10;
 
 fn unwrap_exc_or<T>(exc: Result<T, ()>, def: T) -> T {
     match exc {
@@ -99,21 +97,21 @@ unsafe fn wallet_db(
         .map_err(|e| format_err!("Error opening wallet database connection: {}", e))
 }
 
-/// Helper method for construcing a FsBlockDb value from path data provided over the FFI.
+/// Helper method for construcing a BlockDb value from path data provided over the FFI.
 ///
 /// # Safety
 ///
-/// - `fsblock_db` must be non-null and valid for reads for `fsblock_db_len` bytes, and it must have an
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `fsblock_db` must not be mutated for the duration of the function call.
-/// - The total size `fsblock_db_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
-fn block_db(fsblock_db: *const u8, fsblock_db_len: usize) -> Result<FsBlockDb, failure::Error> {
+unsafe fn block_db(cache_db: *const u8, cache_db_len: usize) -> Result<BlockDb, failure::Error> {
     let cache_db = Path::new(OsStr::from_bytes(unsafe {
-        slice::from_raw_parts(fsblock_db, fsblock_db_len)
+        slice::from_raw_parts(cache_db, cache_db_len)
     }));
-    FsBlockDb::for_path(cache_db)
+    BlockDb::for_path(cache_db)
         .map_err(|e| format_err!("Error opening block source database connection: {}", e))
 }
 
@@ -1640,10 +1638,10 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 }
 
 /// Checks that the scanned blocks in the data database, when combined with the recent
-/// `CompactBlock`s in the block cache, form a valid chain.
+/// `CompactBlock`s in the cache database, form a valid chain.
 ///
 /// This function is built on the core assumption that the information provided in the
-/// block cache is more likely to be accurate than the previously-scanned information.
+/// cache database is more likely to be accurate than the previously-scanned information.
 /// This follows from the design (and trust) assumption that the `lightwalletd` server
 /// provides accurate block information as of the time it was requested.
 ///
@@ -1651,18 +1649,18 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 /// - `-1` if the combined chain is valid.
 /// - `upper_bound` if the combined chain is invalid.
 ///   `upper_bound` is the height of the highest invalid block (on the assumption that the
-///   highest block in the block cache is correct).
+///   highest block in the cache database is correct).
 /// - `0` if there was an error during validation unrelated to chain validity.
 ///
 /// This function does not mutate either of the databases.
 ///
 /// # Safety
 ///
-/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+/// - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
-/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
+/// - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 /// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
@@ -1672,22 +1670,22 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 ///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_validate_combined_chain(
-    fs_block_db_root: *const u8,
-    fs_block_db_root_len: usize,
+    db_cache: *const u8,
+    db_cache_len: usize,
     db_data: *const u8,
     db_data_len: usize,
     network_id: u32,
 ) -> i32 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
-        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
+        let block_db = unsafe { block_db(db_cache, db_cache_len)? };
         let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
 
         let validate_from = (&db_data)
             .get_max_height_hash()
             .map_err(|e| format_err!("Error while validating chain: {}", e))?;
 
-        let val_res = validate_chain(&network, &block_db, validate_from);
+        let val_res = validate_chain(&block_db, validate_from, None);
 
         if let Err(e) = val_res {
             match e {
@@ -1806,11 +1804,11 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
 ///
 /// # Safety
 ///
-/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+/// - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
-/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
+/// - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 /// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
@@ -1820,8 +1818,8 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
 ///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_scan_blocks(
-    fs_block_cache_root: *const u8,
-    fs_block_cache_root_len: usize,
+    db_cache: *const u8,
+    db_cache_len: usize,
     db_data: *const u8,
     db_data_len: usize,
     scan_limit: u32,
@@ -1829,7 +1827,7 @@ pub unsafe extern "C" fn zcashlc_scan_blocks(
 ) -> i32 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
-        let block_db = block_db(fs_block_cache_root, fs_block_cache_root_len)?;
+        let block_db = unsafe { block_db(db_cache, db_cache_len)? };
         let db_read = unsafe { wallet_db(db_data, db_data_len, network)? };
         let mut db_data = db_read.get_update_ops()?;
         let limit = if scan_limit == 0 {
@@ -1910,199 +1908,6 @@ pub unsafe extern "C" fn zcashlc_put_utxo(
         }
     });
     unwrap_exc_or(res, false)
-}
-
-//
-// FsBlock Interfaces
-//
-
-#[repr(C)]
-pub struct FFIBlocksMeta {
-    ptr: *mut FFIBlockMeta,
-    len: usize, // number of elems
-}
-
-impl FFIBlocksMeta {
-    pub fn ptr_from_vec(v: Vec<FFIBlockMeta>) -> *mut Self {
-        // Going from Vec<_> to Box<[_]> just drops the (extra) `capacity`
-        let boxed_slice: Box<[FFIBlockMeta]> = v.into_boxed_slice();
-        let len = boxed_slice.len();
-        let fat_ptr: *mut [FFIBlockMeta] = Box::into_raw(boxed_slice);
-        // It is guaranteed to be possible to obtain a raw pointer to the start
-        // of a slice by casting the pointer-to-slice, as documented e.g. at
-        // <https://doc.rust-lang.org/std/primitive.pointer.html#method.as_mut_ptr>.
-        // TODO: replace with `as_mut_ptr()` when that is stable.
-        let slim_ptr: *mut FFIBlockMeta = fat_ptr as _;
-        Box::into_raw(Box::new(FFIBlocksMeta { ptr: slim_ptr, len }))
-    }
-}
-
-#[repr(C)]
-pub struct FFIBlockMeta {
-    height: u32,
-    block_hash_ptr: *mut u8,
-    block_hash_ptr_len: usize,
-    block_time: u32,
-    sapling_outputs_count: u32,
-    orchard_actions_count: u32,
-}
-
-/// # Safety
-/// Initializes the `FsBlockDb` sqlite database. Does nothing if already created
-///
-/// Returns true when successful, false otherwise. When false is returned caller
-/// should check for errors.
-/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
-///   alignment of `1`. Its contents must be a string representing a valid system path in the
-///   operating system's preferred representation.
-/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
-/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-#[no_mangle]
-pub unsafe extern "C" fn zcashlc_init_block_metadata_db(
-    fs_block_db_root: *const u8,
-    fs_block_db_root_len: usize,
-) -> bool {
-    let res = catch_panic(|| {
-        let mut block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
-
-        match init_blockmeta_db(&mut block_db) {
-            Ok(()) => Ok(true),
-            Err(e) => Err(format_err!(
-                "Error while initializing block metadata DB: {}",
-                e
-            )),
-        }
-    });
-    unwrap_exc_or(res, false)
-}
-
-/// Writes the blocks provided in `blocks_meta` into the `BlockMeta` database
-///
-/// Returns true if the `blocks_meta` could be stored into the `FsBlockDb`. False
-/// otherwise.
-///
-/// When false is returned caller should check for errors.
-///
-/// # Safety
-///
-/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
-///   alignment of `1`. Its contents must be a string representing a valid system path in the
-///   operating system's preferred representation.
-/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
-/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-/// - Block metadata represented in `blocks_meta` must be non-null. Caller must guarantee that the
-/// memory reference by this pointer is not freed up, dereferenced or invalidated while this function
-/// is invoked.
-#[no_mangle]
-pub unsafe extern "C" fn zcashlc_write_block_metadata(
-    fs_block_db_root: *const u8,
-    fs_block_db_root_len: usize,
-    blocks_meta: *mut FFIBlocksMeta,
-) -> bool {
-    let res = catch_panic(|| {
-        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
-
-        let blocks_meta: Box<FFIBlocksMeta> = unsafe { Box::from_raw(blocks_meta) };
-
-        let blocks_metadata_slice: &mut [FFIBlockMeta] =
-            unsafe { slice::from_raw_parts_mut(blocks_meta.ptr, blocks_meta.len) };
-
-        let mut blocks = Vec::with_capacity(blocks_metadata_slice.len());
-
-        for b in blocks_metadata_slice {
-            let block_hash_bytes =
-                unsafe { slice::from_raw_parts(b.block_hash_ptr, b.block_hash_ptr_len) };
-            let mut hash = [0u8; 32];
-            hash.copy_from_slice(block_hash_bytes);
-
-            blocks.push(BlockMeta {
-                height: BlockHeight::from_u32(b.height),
-                block_hash: BlockHash(hash),
-                block_time: b.block_time,
-                sapling_outputs_count: b.sapling_outputs_count,
-                orchard_actions_count: b.orchard_actions_count,
-            });
-        }
-
-        match block_db.write_block_metadata(&blocks) {
-            Ok(()) => Ok(true),
-            Err(e) => Err(format_err!(
-                "Failed to write block metadata to FsBlockDb: {:?}",
-                e
-            )),
-        }
-    });
-    unwrap_exc_or(res, false)
-}
-
-/// Rewinds the data database to the given height.
-///
-/// If the requested height is greater than or equal to the height of the last scanned
-/// block, this function does nothing.
-///
-/// # Safety
-///
-/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
-///   alignment of `1`. Its contents must be a string representing a valid system path in the
-///   operating system's preferred representation.
-/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
-/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-#[no_mangle]
-pub unsafe extern "C" fn zcashlc_rewind_fs_block_cache_to_height(
-    fs_block_db_root: *const u8,
-    fs_block_db_root_len: usize,
-    height: i32,
-) -> bool {
-    let res = catch_panic(|| {
-        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
-        let height = BlockHeight::try_from(height)?;
-        block_db
-            .rewind_to_height(height)
-            .map(|_| true)
-            .map_err(|e| format_err!("Error while rewinding data DB to height {}: {}", height, e))
-    });
-    unwrap_exc_or(res, false)
-}
-
-/// Get the latest cached block height in the filesystem block cache
-///
-/// Returns a positive blockheight or -1 if empty or an error occurred.
-///
-/// # Safety
-///
-/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
-///   alignment of `1`. Its contents must be a string representing a valid system path in the
-///   operating system's preferred representation.
-/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
-/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-/// - `tx` must be non-null and valid for reads for `tx_len` bytes, and it must have an
-///   alignment of `1`.
-/// - The memory referenced by `tx` must not be mutated for the duration of the function call.
-/// - The total size `tx_len` must be no larger than `isize::MAX`. See the safety
-///   documentation of pointer::offset.
-#[no_mangle]
-pub unsafe extern "C" fn zcashlc_latest_cached_block_height(
-    fs_block_db_root: *const u8,
-    fs_block_db_root_len: usize,
-) -> i32 {
-    let res = catch_panic(|| {
-        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
-
-        match block_db.get_max_cached_height() {
-            Ok(Some(block_height)) => Ok(u32::from(block_height) as i32),
-            Ok(None) => Ok(-1),
-            Err(e) => Err(format_err!(
-                "Failed to read block metadata from FsBlockDb: {:?}",
-                e
-            )),
-        }
-    });
-
-    unwrap_exc_or(res, -1)
 }
 
 /// Decrypts whatever parts of the specified transaction it can and stores them in db_data.
@@ -2216,6 +2021,7 @@ pub unsafe extern "C" fn zcashlc_create_to_address(
         if value.is_negative() {
             return Err(format_err!("Amount is negative"));
         }
+
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
         }));
@@ -2340,7 +2146,6 @@ pub unsafe extern "C" fn zcashlc_string_free(s: *mut c_char) {
 /// - The memory referenced by `usk_ptr` must not be mutated for the duration of the function call.
 /// - The total size `usk_len` must be no larger than `isize::MAX`. See the safety documentation
 /// - `memo` must either be null (indicating an empty memo) or point to a 512-byte array.
-/// - `shielding_threshold` a non-negative shielding threshold amount in zatoshi
 /// - `spend_params` must be non-null and valid for reads for `spend_params_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be the Sapling spend proving parameters.
 /// - The memory referenced by `spend_params` must not be mutated for the duration of the function call.
@@ -2357,12 +2162,13 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
     db_data_len: usize,
     usk_ptr: *const u8,
     usk_len: usize,
+    shielding_threshold: i64,
     memo: *const u8,
-    shielding_threshold: u64,
     spend_params: *const u8,
     spend_params_len: usize,
     output_params: *const u8,
     output_params_len: usize,
+    min_confirmations: u32,
     network_id: u32,
     use_zip317_fees: bool,
 ) -> i64 {
@@ -2373,6 +2179,9 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
             .get_update_ops()
             .map_err(|e| format_err!("Could not obtain a writable database connection: {}", e))?;
 
+        let threshold = NonNegativeAmount::from_nonnegative_i64(shielding_threshold)
+        .map_err(|()| format_err!("Invalid amount, out of range"))?;
+
         let usk = unsafe { decode_usk(usk_ptr, usk_len) }?;
 
         let memo_bytes = if memo.is_null() {
@@ -2381,9 +2190,6 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
             MemoBytes::from_bytes(unsafe { slice::from_raw_parts(memo, 512) })
                 .map_err(|e| format_err!("Invalid MemoBytes {}", e))?
         };
-
-        let shielding_threshold = NonNegativeAmount::from_u64(shielding_threshold)
-            .map_err(|()| format_err!("Invalid amount, out of range"))?;
 
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
@@ -2430,11 +2236,11 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &network,
                 LocalTxProver::new(spend_params, output_params),
                 &input_selector,
-                shielding_threshold,
+                threshold,
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                ANCHOR_OFFSET,
+                min_confirmations,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         } else {
@@ -2448,11 +2254,11 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &network,
                 LocalTxProver::new(spend_params, output_params),
                 &input_selector,
-                shielding_threshold,
+                threshold,
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                ANCHOR_OFFSET,
+                min_confirmations,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -4,8 +4,6 @@ use failure::format_err;
 use ffi_helpers::panic::catch_panic;
 use schemer::MigratorError;
 use secrecy::Secret;
-use zcash_primitives::transaction::components::amount::NonNegativeAmount;
-
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::ffi::{CStr, CString, OsStr};
@@ -14,6 +12,7 @@ use std::os::raw::c_char;
 use std::os::unix::ffi::OsStrExt;
 use std::path::Path;
 use std::slice;
+use zcash_primitives::transaction::components::amount::NonNegativeAmount;
 
 use zcash_address::{
     self,
@@ -39,8 +38,9 @@ use zcash_client_backend::{
 #[allow(deprecated)]
 use zcash_client_sqlite::wallet::get_rewind_height;
 use zcash_client_sqlite::{
+    chain::{init::init_blockmeta_db, BlockMeta},
     wallet::init::{init_accounts_table, init_blocks_table, init_wallet_db, WalletMigrationError},
-    BlockDb, NoteId, WalletDb,
+    FsBlockDb, NoteId, WalletDb,
 };
 use zcash_primitives::consensus::Network::{MainNetwork, TestNetwork};
 use zcash_primitives::{
@@ -57,6 +57,8 @@ use zcash_primitives::{
     zip32::AccountId,
 };
 use zcash_proofs::prover::LocalTxProver;
+
+const ANCHOR_OFFSET: u32 = 10;
 
 fn unwrap_exc_or<T>(exc: Result<T, ()>, def: T) -> T {
     match exc {
@@ -97,21 +99,21 @@ unsafe fn wallet_db(
         .map_err(|e| format_err!("Error opening wallet database connection: {}", e))
 }
 
-/// Helper method for construcing a BlockDb value from path data provided over the FFI.
+/// Helper method for construcing a FsBlockDb value from path data provided over the FFI.
 ///
 /// # Safety
 ///
-/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+/// - `fsblock_db` must be non-null and valid for reads for `fsblock_db_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
-/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `fsblock_db` must not be mutated for the duration of the function call.
+/// - The total size `fsblock_db_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
-unsafe fn block_db(cache_db: *const u8, cache_db_len: usize) -> Result<BlockDb, failure::Error> {
+fn block_db(fsblock_db: *const u8, fsblock_db_len: usize) -> Result<FsBlockDb, failure::Error> {
     let cache_db = Path::new(OsStr::from_bytes(unsafe {
-        slice::from_raw_parts(cache_db, cache_db_len)
+        slice::from_raw_parts(fsblock_db, fsblock_db_len)
     }));
-    BlockDb::for_path(cache_db)
+    FsBlockDb::for_path(cache_db)
         .map_err(|e| format_err!("Error opening block source database connection: {}", e))
 }
 
@@ -1638,10 +1640,10 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 }
 
 /// Checks that the scanned blocks in the data database, when combined with the recent
-/// `CompactBlock`s in the cache database, form a valid chain.
+/// `CompactBlock`s in the block cache, form a valid chain.
 ///
 /// This function is built on the core assumption that the information provided in the
-/// cache database is more likely to be accurate than the previously-scanned information.
+/// block cache is more likely to be accurate than the previously-scanned information.
 /// This follows from the design (and trust) assumption that the `lightwalletd` server
 /// provides accurate block information as of the time it was requested.
 ///
@@ -1649,18 +1651,18 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 /// - `-1` if the combined chain is valid.
 /// - `upper_bound` if the combined chain is invalid.
 ///   `upper_bound` is the height of the highest invalid block (on the assumption that the
-///   highest block in the cache database is correct).
+///   highest block in the block cache is correct).
 /// - `0` if there was an error during validation unrelated to chain validity.
 ///
 /// This function does not mutate either of the databases.
 ///
 /// # Safety
 ///
-/// - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
-/// - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 /// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
@@ -1670,22 +1672,22 @@ pub unsafe extern "C" fn zcashlc_get_sent_memo(
 ///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_validate_combined_chain(
-    db_cache: *const u8,
-    db_cache_len: usize,
+    fs_block_db_root: *const u8,
+    fs_block_db_root_len: usize,
     db_data: *const u8,
     db_data_len: usize,
     network_id: u32,
 ) -> i32 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
-        let block_db = unsafe { block_db(db_cache, db_cache_len)? };
+        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
         let db_data = unsafe { wallet_db(db_data, db_data_len, network)? };
 
         let validate_from = (&db_data)
             .get_max_height_hash()
             .map_err(|e| format_err!("Error while validating chain: {}", e))?;
 
-        let val_res = validate_chain(&block_db, validate_from, None);
+        let val_res = validate_chain(&network, &block_db, validate_from);
 
         if let Err(e) = val_res {
             match e {
@@ -1804,11 +1806,11 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
 ///
 /// # Safety
 ///
-/// - `db_cache` must be non-null and valid for reads for `db_cache_len` bytes, and it must have an
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
 ///   operating system's preferred representation.
-/// - The memory referenced by `db_cache` must not be mutated for the duration of the function call.
-/// - The total size `db_cache_len` must be no larger than `isize::MAX`. See the safety
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
 ///   documentation of pointer::offset.
 /// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be a string representing a valid system path in the
@@ -1818,8 +1820,8 @@ pub unsafe extern "C" fn zcashlc_rewind_to_height(
 ///   documentation of pointer::offset.
 #[no_mangle]
 pub unsafe extern "C" fn zcashlc_scan_blocks(
-    db_cache: *const u8,
-    db_cache_len: usize,
+    fs_block_cache_root: *const u8,
+    fs_block_cache_root_len: usize,
     db_data: *const u8,
     db_data_len: usize,
     scan_limit: u32,
@@ -1827,7 +1829,7 @@ pub unsafe extern "C" fn zcashlc_scan_blocks(
 ) -> i32 {
     let res = catch_panic(|| {
         let network = parse_network(network_id)?;
-        let block_db = unsafe { block_db(db_cache, db_cache_len)? };
+        let block_db = block_db(fs_block_cache_root, fs_block_cache_root_len)?;
         let db_read = unsafe { wallet_db(db_data, db_data_len, network)? };
         let mut db_data = db_read.get_update_ops()?;
         let limit = if scan_limit == 0 {
@@ -1908,6 +1910,199 @@ pub unsafe extern "C" fn zcashlc_put_utxo(
         }
     });
     unwrap_exc_or(res, false)
+}
+
+//
+// FsBlock Interfaces
+//
+
+#[repr(C)]
+pub struct FFIBlocksMeta {
+    ptr: *mut FFIBlockMeta,
+    len: usize, // number of elems
+}
+
+impl FFIBlocksMeta {
+    pub fn ptr_from_vec(v: Vec<FFIBlockMeta>) -> *mut Self {
+        // Going from Vec<_> to Box<[_]> just drops the (extra) `capacity`
+        let boxed_slice: Box<[FFIBlockMeta]> = v.into_boxed_slice();
+        let len = boxed_slice.len();
+        let fat_ptr: *mut [FFIBlockMeta] = Box::into_raw(boxed_slice);
+        // It is guaranteed to be possible to obtain a raw pointer to the start
+        // of a slice by casting the pointer-to-slice, as documented e.g. at
+        // <https://doc.rust-lang.org/std/primitive.pointer.html#method.as_mut_ptr>.
+        // TODO: replace with `as_mut_ptr()` when that is stable.
+        let slim_ptr: *mut FFIBlockMeta = fat_ptr as _;
+        Box::into_raw(Box::new(FFIBlocksMeta { ptr: slim_ptr, len }))
+    }
+}
+
+#[repr(C)]
+pub struct FFIBlockMeta {
+    height: u32,
+    block_hash_ptr: *mut u8,
+    block_hash_ptr_len: usize,
+    block_time: u32,
+    sapling_outputs_count: u32,
+    orchard_actions_count: u32,
+}
+
+/// # Safety
+/// Initializes the `FsBlockDb` sqlite database. Does nothing if already created
+///
+/// Returns true when successful, false otherwise. When false is returned caller
+/// should check for errors.
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+#[no_mangle]
+pub unsafe extern "C" fn zcashlc_init_block_metadata_db(
+    fs_block_db_root: *const u8,
+    fs_block_db_root_len: usize,
+) -> bool {
+    let res = catch_panic(|| {
+        let mut block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
+
+        match init_blockmeta_db(&mut block_db) {
+            Ok(()) => Ok(true),
+            Err(e) => Err(format_err!(
+                "Error while initializing block metadata DB: {}",
+                e
+            )),
+        }
+    });
+    unwrap_exc_or(res, false)
+}
+
+/// Writes the blocks provided in `blocks_meta` into the `BlockMeta` database
+///
+/// Returns true if the `blocks_meta` could be stored into the `FsBlockDb`. False
+/// otherwise.
+///
+/// When false is returned caller should check for errors.
+///
+/// # Safety
+///
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+/// - Block metadata represented in `blocks_meta` must be non-null. Caller must guarantee that the
+/// memory reference by this pointer is not freed up, dereferenced or invalidated while this function
+/// is invoked.
+#[no_mangle]
+pub unsafe extern "C" fn zcashlc_write_block_metadata(
+    fs_block_db_root: *const u8,
+    fs_block_db_root_len: usize,
+    blocks_meta: *mut FFIBlocksMeta,
+) -> bool {
+    let res = catch_panic(|| {
+        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
+
+        let blocks_meta: Box<FFIBlocksMeta> = unsafe { Box::from_raw(blocks_meta) };
+
+        let blocks_metadata_slice: &mut [FFIBlockMeta] =
+            unsafe { slice::from_raw_parts_mut(blocks_meta.ptr, blocks_meta.len) };
+
+        let mut blocks = Vec::with_capacity(blocks_metadata_slice.len());
+
+        for b in blocks_metadata_slice {
+            let block_hash_bytes =
+                unsafe { slice::from_raw_parts(b.block_hash_ptr, b.block_hash_ptr_len) };
+            let mut hash = [0u8; 32];
+            hash.copy_from_slice(block_hash_bytes);
+
+            blocks.push(BlockMeta {
+                height: BlockHeight::from_u32(b.height),
+                block_hash: BlockHash(hash),
+                block_time: b.block_time,
+                sapling_outputs_count: b.sapling_outputs_count,
+                orchard_actions_count: b.orchard_actions_count,
+            });
+        }
+
+        match block_db.write_block_metadata(&blocks) {
+            Ok(()) => Ok(true),
+            Err(e) => Err(format_err!(
+                "Failed to write block metadata to FsBlockDb: {:?}",
+                e
+            )),
+        }
+    });
+    unwrap_exc_or(res, false)
+}
+
+/// Rewinds the data database to the given height.
+///
+/// If the requested height is greater than or equal to the height of the last scanned
+/// block, this function does nothing.
+///
+/// # Safety
+///
+/// - `fs_block_db_root` must be non-null and valid for reads for `fs_block_db_root_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `fs_block_db_root` must not be mutated for the duration of the function call.
+/// - The total size `fs_block_db_root_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+#[no_mangle]
+pub unsafe extern "C" fn zcashlc_rewind_fs_block_cache_to_height(
+    fs_block_db_root: *const u8,
+    fs_block_db_root_len: usize,
+    height: i32,
+) -> bool {
+    let res = catch_panic(|| {
+        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
+        let height = BlockHeight::try_from(height)?;
+        block_db
+            .rewind_to_height(height)
+            .map(|_| true)
+            .map_err(|e| format_err!("Error while rewinding data DB to height {}: {}", height, e))
+    });
+    unwrap_exc_or(res, false)
+}
+
+/// Get the latest cached block height in the filesystem block cache
+///
+/// Returns a positive blockheight or -1 if empty or an error occurred.
+///
+/// # Safety
+///
+/// - `db_data` must be non-null and valid for reads for `db_data_len` bytes, and it must have an
+///   alignment of `1`. Its contents must be a string representing a valid system path in the
+///   operating system's preferred representation.
+/// - The memory referenced by `db_data` must not be mutated for the duration of the function call.
+/// - The total size `db_data_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+/// - `tx` must be non-null and valid for reads for `tx_len` bytes, and it must have an
+///   alignment of `1`.
+/// - The memory referenced by `tx` must not be mutated for the duration of the function call.
+/// - The total size `tx_len` must be no larger than `isize::MAX`. See the safety
+///   documentation of pointer::offset.
+#[no_mangle]
+pub unsafe extern "C" fn zcashlc_latest_cached_block_height(
+    fs_block_db_root: *const u8,
+    fs_block_db_root_len: usize,
+) -> i32 {
+    let res = catch_panic(|| {
+        let block_db = block_db(fs_block_db_root, fs_block_db_root_len)?;
+
+        match block_db.get_max_cached_height() {
+            Ok(Some(block_height)) => Ok(u32::from(block_height) as i32),
+            Ok(None) => Ok(-1),
+            Err(e) => Err(format_err!(
+                "Failed to read block metadata from FsBlockDb: {:?}",
+                e
+            )),
+        }
+    });
+
+    unwrap_exc_or(res, -1)
 }
 
 /// Decrypts whatever parts of the specified transaction it can and stores them in db_data.
@@ -2021,7 +2216,6 @@ pub unsafe extern "C" fn zcashlc_create_to_address(
         if value.is_negative() {
             return Err(format_err!("Amount is negative"));
         }
-
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
         }));
@@ -2146,6 +2340,7 @@ pub unsafe extern "C" fn zcashlc_string_free(s: *mut c_char) {
 /// - The memory referenced by `usk_ptr` must not be mutated for the duration of the function call.
 /// - The total size `usk_len` must be no larger than `isize::MAX`. See the safety documentation
 /// - `memo` must either be null (indicating an empty memo) or point to a 512-byte array.
+/// - `shielding_threshold` a non-negative shielding threshold amount in zatoshi
 /// - `spend_params` must be non-null and valid for reads for `spend_params_len` bytes, and it must have an
 ///   alignment of `1`. Its contents must be the Sapling spend proving parameters.
 /// - The memory referenced by `spend_params` must not be mutated for the duration of the function call.
@@ -2162,13 +2357,12 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
     db_data_len: usize,
     usk_ptr: *const u8,
     usk_len: usize,
-    shielding_threshold: i64,
     memo: *const u8,
+    shielding_threshold: u64,
     spend_params: *const u8,
     spend_params_len: usize,
     output_params: *const u8,
     output_params_len: usize,
-    min_confirmations: u32,
     network_id: u32,
     use_zip317_fees: bool,
 ) -> i64 {
@@ -2179,9 +2373,6 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
             .get_update_ops()
             .map_err(|e| format_err!("Could not obtain a writable database connection: {}", e))?;
 
-        let threshold = NonNegativeAmount::from_nonnegative_i64(shielding_threshold)
-        .map_err(|()| format_err!("Invalid amount, out of range"))?;
-
         let usk = unsafe { decode_usk(usk_ptr, usk_len) }?;
 
         let memo_bytes = if memo.is_null() {
@@ -2190,6 +2381,9 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
             MemoBytes::from_bytes(unsafe { slice::from_raw_parts(memo, 512) })
                 .map_err(|e| format_err!("Invalid MemoBytes {}", e))?
         };
+
+        let shielding_threshold = NonNegativeAmount::from_u64(shielding_threshold)
+            .map_err(|()| format_err!("Invalid amount, out of range"))?;
 
         let spend_params = Path::new(OsStr::from_bytes(unsafe {
             slice::from_raw_parts(spend_params, spend_params_len)
@@ -2236,11 +2430,11 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &network,
                 LocalTxProver::new(spend_params, output_params),
                 &input_selector,
-                threshold,
+                shielding_threshold,
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                min_confirmations,
+                ANCHOR_OFFSET,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         } else {
@@ -2254,11 +2448,11 @@ pub unsafe extern "C" fn zcashlc_shield_funds(
                 &network,
                 LocalTxProver::new(spend_params, output_params),
                 &input_selector,
-                threshold,
+                shielding_threshold,
                 &usk,
                 &taddrs,
                 &memo_bytes,
-                min_confirmations,
+                ANCHOR_OFFSET,
             )
             .map_err(|e| format_err!("Error while shielding transaction: {}", e))
         }


### PR DESCRIPTION
This is the initial implementation of the rust FFI code for using FsBlockDb from Swift. 

It's based on https://github.com/zcash/zcash-android-wallet-sdk/pull/804

It points to a branch because I need to code a fmt::Display trait compliance for the FsBlockError enum which I could implement from the FFI module itself. 
Closes #81 
Closes #73