### PR TITLE
[#34] Fix SwiftPackageManager deprecation Warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# unreleased
+# unreleased [version 0.1.2]
+- [#34] Fix SwiftPackageManager deprecation Warning
+We had to change the name of the package to make it match the name 
+of the github repository due to Swift Package Manager conventions.
+
+please see README.md for more information on how to import this package
+going forward.
 
 - [#78] removing cocoapods support
 # 0.1.1

--- a/Package.swift
+++ b/Package.swift
@@ -3,10 +3,10 @@
 import PackageDescription
 
 let package = Package(
-    name: "libzcashlc",
+    name: "zcash-light-client-ffi",
     products: [
         .library(
-            name: "libzcashlc",
+            name: "zcash-light-client-ffi",
             targets: ["libzcashlc"]
         ),
     ],

--- a/README.md
+++ b/README.md
@@ -8,6 +8,26 @@ This project is designed for two things:
 Currently implemented is building for apple platforms as an `xcframework` and for distribution via Swift Package Manager.
 
 
+## importing the package
+Add the package as a dependency
+````Swift
+dependencies: [
+  .package(url: "https://github.com/zcash-hackworks/zcash-light-client-ffi", from: "0.1.2")
+  // other dependencies
+]
+````
+
+and reference it as product in the target that it will be used
+
+````Swift
+targets: [
+        .target(
+            name: "MyTarget",
+            dependencies: [
+                .product(name: "libzcashlc", package: "zcash-light-client-ffi")
+            ],
+````
+
 ## Building
 
 ### Pre-requisites


### PR DESCRIPTION
Closes #34 

This fixes a deprecation warning around the name of the package. 

needs a subsequent PR on ZcashLightClientKit #754